### PR TITLE
[codex] Fix Mac mini mise PATH order

### DIFF
--- a/setup/mac-mini/.zshrc
+++ b/setup/mac-mini/.zshrc
@@ -50,7 +50,6 @@ fi
 # -----------------------------------------------------------------------------
 # Environment
 # -----------------------------------------------------------------------------
-_activate_mise
 export PATH="/opt/homebrew/opt/curl/bin:$PATH"
 export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"
 if [[ -f "$HOME/.local/bin/env" ]]; then
@@ -104,3 +103,5 @@ case ":$PATH:" in
   *) export PATH="$PNPM_HOME:$PATH" ;;
 esac
 # pnpm end
+
+_activate_mise


### PR DESCRIPTION
## Summary

- Move `_activate_mise` to the end of the Mac mini environment setup in `setup/mac-mini/.zshrc`.
- Keep mini-specific PATH entries for curl, PostgreSQL, local bin, OpenClaw completions, and pnpm intact.
- Let mise re-prepend its managed runtime paths after those host-specific PATH edits.

## Why

`mise doctor` warned on the Mac mini that `~/Library/pnpm`, PostgreSQL, and curl paths were taking precedence over mise-managed tools. The root cause was `_activate_mise` running before the mini-specific PATH exports.

## Validation

- `zsh -n setup/mac-mini/.zshrc`
- On Mac mini branch checkout:
  - `zsh -lic "mise doctor"` -> `No problems found`
  - `node -v` -> `v26.1.0` from mise
  - `pnpm -v` -> `10.32.1`
  - `uv --version` -> `uv 0.11.14`